### PR TITLE
Fix: 'View raw' parameter typo

### DIFF
--- a/legacy/index.php
+++ b/legacy/index.php
@@ -332,7 +332,7 @@ ROW;
 				?>
 			</table>
 			<div class="links">
-				<a href="/?id=<?php echo $reportId ?? 0 ?>&amp;accessToken=<?php echo $accessToken ?? "" ?>&amp;raw=1">View raw</a>
+				<a href="/?id=<?php echo $reportId ?? 0 ?>&amp;access_token=<?php echo $accessToken ?? "" ?>&amp;raw=1">View raw</a>
 				<br><br>
 				<?php if(($accessToken ?? "") !== ""){ ?>
 				<span class="private-report-notice">This is a private report. Make sure to copy the URL if you want to view it again in the future.</span>


### PR DESCRIPTION
An error occurs when using `accessToken`.

```json
{"error":"Incorrect or no access token provided"}
```

Now it works correctly with `access_token`.